### PR TITLE
(fix): Remove trailing slash because it doesn't work on googlestorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.2
+
+Remove trailing slash on cql_base_url since the new url does not support it.
+
 # 0.3.1
 
 Update cql_base_url link to https://storage.googleapis.com/google-code-archive-downloads/v2/apache-extras.org/cassandra-dbapi2/ since the previous link no longer resolves.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@ require 'pathname'
 
 default['cassandra']['version'] = '20130603180240'
 default['cassandra']['cql_version']  = '1.0.5'
-default['cassandra']['cql_base_url'] = 'https://storage.googleapis.com/google-code-archive-downloads/v2/apache-extras.org/cassandra-dbapi2/'
+default['cassandra']['cql_base_url'] = 'https://storage.googleapis.com/google-code-archive-downloads/v2/apache-extras.org/cassandra-dbapi2'
 # 'http://cassandra-dbapi2.apache-extras.org.codespot.com/files/'
 # 'https://storage.googleapis.com/google-code-archive-downloads/v1/apache-extras.org/cassandra-dbapi2/'
 default['cassandra']['cassandra_syncer_version'] = '1024d7144d574f87062546f3b6cffedc7158c1ca'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.1'
+version '0.3.2'
 
 depends 'archives'
 depends 'java'


### PR DESCRIPTION
```
==> default: [2016-08-27T06:42:45+00:00] WARN: remote_file[/usr/src/cql-1.0.5.tar.gz] cannot be downloaded from https://storage.googleapis.com/google-code-archive-downloads/v2/apache-extras.org/cassandra-dbapi2//cql-1.0.5.tar.gz: 404 "Not Found"
```

double slash doesn't work :(