### PR TITLE
add in_memory_compaction_limit

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,7 @@ default['cassandra']['hinted_handoff_enabled'] = true
 default['cassandra']['rpc_server_type'] = 'hsha'
 default['cassandra']['rpc_max_threads'] = 2048
 default['cassandra']['thrift_max_message_length_in_mb'] = 16
+default['cassandra']['in_memory_compaction_limit_in_mb'] = 64
 
 # Ports
 default['cassandra']['inter_dc_tcp_nodelay'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sfo-devops@lists.rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures Cassandra'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.6'
+version '0.3.7'
 
 depends 'archives'
 depends 'java'

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -262,7 +262,7 @@ column_index_size_in_kb: 64
 # Size limit for rows being compacted in memory.  Larger rows will spill
 # over to disk and use a slower two-pass compaction process.  A message
 # will be logged specifying the row key.
-in_memory_compaction_limit_in_mb: 64
+in_memory_compaction_limit_in_mb: <%= node['cassandra']['in_memory_compaction_limit_in_mb'] %>
 
 # Number of simultaneous compactions to allow, NOT including
 # validation "compactions" for anti-entropy repair.  Simultaneous


### PR DESCRIPTION
Allow us to tune the in memory compaction limit variable. It should be 5-10% of the heap size.