### PR TITLE
Update cassandra_cluster.rb

### DIFF
--- a/definitions/cassandra_cluster.rb
+++ b/definitions/cassandra_cluster.rb
@@ -2,6 +2,7 @@ define :cassandra_cluster do
   include_recipe 'cassandra::cassandra'
 
   cluster_type = params[:name]
+  token = params[:token] || node['cassandra']['initial_token']
 
   # TODO : move to non ele-specific path
   template "/opt/ele-conf/#{cluster_type}.yaml" do
@@ -13,7 +14,7 @@ define :cassandra_cluster do
       cass_seed_servers: node['cassandra']['seed_servers'],
       cluster_name: node['cassandra']['cluster_name'],
       listen_ip: node['cassandra']['listen_ip'],
-      initial_token: node['cassandra']['initial_token']
+      initial_token: token
     )
   end
 

--- a/templates/default/cassandra.yaml.erb
+++ b/templates/default/cassandra.yaml.erb
@@ -9,6 +9,7 @@
 # one logical cluster from joining another.
 cluster_name: <%= @cluster_name %>
 
+<% if @initial_token -%>
 # You should always specify InitialToken when setting up a production
 # cluster for the first time, and often when adding capacity later.
 # The principle is that each node should be given an equal slice of
@@ -20,6 +21,7 @@ cluster_name: <%= @cluster_name %>
 # available, such as is the case with a new cluster, it will pick
 # a random token, which will lead to hot spots.
 initial_token: <%= @initial_token %>
+<% end -%>
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
 hinted_handoff_enabled: <%= node['cassandra']['hinted_handoff_enabled'] %>


### PR DESCRIPTION
Currently, we set the initial token to `0` as fallback logic. This lead to bringing online a new cass node that had wrongly used `0` as its initial_token and bump an existing node from the cluster.

Ideally, even if the node was online, it should have no `initial_token`, so that it doesn't take over a full slice of the keyspace (and can be `nodetool move`'d as needed).

for 1-node clusters (raxvm), not setting an initial token should have no negative impact.