### PR TITLE
Optimizing G1

### DIFF
--- a/templates/default/sv-cassandra-run.erb
+++ b/templates/default/sv-cassandra-run.erb
@@ -25,6 +25,7 @@ exec chpst -u daemon -o 65535 \
         -Xms<%= @options[:min_memory] %> \
         -Xmx<%= @options[:max_memory] %> \
         -XX:+UseG1GC \
+        -XX:+UseStringDeduplication \
         -XX:MaxGCPauseMillis=500 \
         -XX:G1RSetUpdatingPauseTimePercent=5 \
         -XX:+ParallelRefProcEnabled \


### PR DESCRIPTION
# What:
Adding an extra flag to further optimize the heap

# How: 
Whenever the garbage collector visits String objects it takes note of the char arrays. It takes their hash value and stores it alongside with a weak reference to the array. As soon as it finds another String which has the same hash code it compares them char by char.
If they match as well, one String will be modified and point to the char array of the second String. The first char array then is no longer referenced anymore and can be garbage collected.

## Caveat:
Works only with Java 8 realeses after update 20. But, we already have updated Java on our C* nodes.